### PR TITLE
Remove `default` as a dependency

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = cozy
-depends = default, player_api
+depends = player_api
 optional_depends = player_monoids
 description = Adds sitting down, and lying down player animations.


### PR DESCRIPTION
Things added/changed:

- Remove `default` as a dependency.
  - No `default` calls are found in the code, making it pointless to have it as a hard dependency.
